### PR TITLE
make sure name is findable

### DIFF
--- a/project/Assets/SeinJSUnityToolkit/Exporter/ExporterEntry.cs
+++ b/project/Assets/SeinJSUnityToolkit/Exporter/ExporterEntry.cs
@@ -1028,7 +1028,8 @@ namespace SeinJS
             int accessorId = 0;
             foreach (var target in targets)
             {
-                var targetTr = tr.Find(targets[targetId]);
+                var targetName = targets[targetId].Replace("/", "");
+                var targetTr = tr.Find(targetName);
                 var targetNode = tr2node[targetTr];
 
                 foreach (var accessor in accessors[targetId])


### PR DESCRIPTION
Case
```
- door  --- ( has Animator )
   - Circle.001
   - Cirlcle.002
```
BakeAnimationClip will return an Array 
```C#
["/Circle.001",  "/Circle.002"]
```
thus
```C#
transform.Find("/Circle.001")
```
will return null,  
then ` tr2node[null] ` will throw Error

